### PR TITLE
Add Docker configuration for HF Space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim
+
+# Install dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Copy flow file and assets
+WORKDIR /app
+COPY trueeye_flow.json ./
+COPY .assets ./assets
+
+# Expose the port used by LangFlow
+EXPOSE 7860
+
+# Run the LangFlow server
+CMD ["langflow", "run", "trueeye_flow.json", "--host", "0.0.0.0", "--port", "7860"]

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ After a year of daily experimentation with the major LLMs, **Claude’s Constitu
 ```bash
 git clone https://github.com/<user>/trueeye.git
 cd trueeye
-pip install -r requirements.txt
-export ANTHROPIC_API_KEY="sk-..."   # your real key
-python app.py                       # http://127.0.0.1:7860
+docker build -t trueeye .
+docker run -it -e ANTHROPIC_API_KEY="sk-..." -p 7860:7860 trueeye
 ```
 
-> Runs on plain CPU; heavy lifting happens on Anthropic’s servers.
+> The LangFlow UI will be available at http://127.0.0.1:7860
 
 ---
 
@@ -66,10 +65,9 @@ python app.py                       # http://127.0.0.1:7860
 ```
 trueeye/
 ├─ trueeye_flow.json   → LangFlow graph
-├─ app.py              → Gradio UI
-├─ requirements.txt
-├─ .assets/            → logos, demo GIF
-└─ docs/               → specs, notes, roadmap
+├─ requirements.txt    → Python dependencies
+├─ Dockerfile          → container recipe for HF Spaces
+├─ .assets/            → logos
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,20 @@
+# Núcleo del flujo construido en LangFlow
+langflow>=1.4.2          # carga el .json y ejecuta el grafo
+langchain>=0.1.17        # aseguramos versión compatible con langflow
+
+# Modelo remoto Anthropic
+anthropic>=0.16.0        # Claude 3 (Haiku/Sonnet/Opus)
+
+# Interfaz
+gradio>=4.14.0,<5        # requiere componentes Gauge & HighlightedText
+
+# Utilidades auxiliares
+tiktoken>=0.5.2          # token counting (usado internamente por langchain)
+requests>=2.31.0         # descargas ocasionales si amplías el flujo
+python-dotenv>=1.0.1     # cargar ANTHROPIC_API_KEY desde .env local (opcional)
+beautifulsoup4>=4.12.2   # HTML parsing for the RecursiveUrlLoader
+httpx>=0.24.1            # async HTTP client used by custom loader
+loguru>=0.7.2            # advanced logging during execution
+
+# Fixes de compatibilidad (HF base image a veces los omite)
+typing-extensions>=4.10  # para modelos recientes de Python 3.10


### PR DESCRIPTION
## Summary
- add `Dockerfile` for HF Spaces (LangFlow server)
- restore `requirements.txt`
- update `README` quick start for Docker

## Testing
- `pip install --dry-run -r requirements.txt` *(fails: subprocess-exited-with-error)*

------
https://chatgpt.com/codex/tasks/task_e_6855ff541b6c8322a4d80e4bcfa54b8e